### PR TITLE
Use latest images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - p8e
 
   object-store:
-    image: ghcr.io/provenance-io/object-store:0.1.0
+    image: ghcr.io/provenance-io/object-store:latest
     container_name: object-store
     networks:
       - p8e
@@ -67,7 +67,7 @@ services:
       - ./os_storage_bucket:/mnt/data
 
   p8e-migrate:
-    image: ghcr.io/provenance-io/p8e-migration:0.7.1
+    image: ghcr.io/provenance-io/p8e-migration:latest
     container_name: p8e-migrate
     networks:
       - p8e
@@ -81,7 +81,7 @@ services:
     command: migrate
 
   p8e:
-    image: ghcr.io/provenance-io/p8e-api:0.7.1
+    image: ghcr.io/provenance-io/p8e-api:latest
     container_name: p8e
     networks:
       - p8e
@@ -97,7 +97,7 @@ services:
       - 5002:8080
 
   p8e-webservice:
-    image: ghcr.io/provenance-io/p8e-api-webservice:0.7.1
+    image: ghcr.io/provenance-io/p8e-api-webservice:latest
     container_name: p8e-webservice
     networks:
       - p8e
@@ -110,7 +110,7 @@ services:
       - 5003:8090
 
   p8e-ui:
-    image: ghcr.io/provenance-io/p8e-ui:0.6.0-public-release-beta.2
+    image: ghcr.io/provenance-io/p8e-ui:latest
     container_name: p8e-ui
     networks:
       - p8e


### PR DESCRIPTION
Move all p8e docker images to latest so that we can track their latest release. Now that Figure is back onto a single configuration, we can use latest for all the images so we don't have to upgrade them over time.